### PR TITLE
removed ubuntu precise from testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This role configures the following.
 Version
 -------
 
+* `2.1.4` --- removed ubuntu precise from testing
 * `2.1.3` --- added tests for ubuntu focal, 20.04
 * `2.1.2` --- tested with Ansible 2.9.11
 * `2.1.1` --- prepare for github

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -9,7 +9,6 @@ Vagrant.configure("2") do |config|
     { :name => "bionic", :box => "ubuntu/bionic64" },
     { :name => "xenial", :box => "ubuntu/xenial64" },
     { :name => "trusty", :box => "ubuntu/trusty64" },
-    { :name => "precise", :box => "ubuntu/precise64" },
     { :name => "centos8", :box => "centos/8" },
     { :name => "centos7", :box => "centos/7" },
     { :name => "centos6", :box => "centos/6" },


### PR DESCRIPTION
Hi!

I'd like to contribute bugfix.

Ubuntu isn't publishing the old Precise image on Vagrant Cloud anymore.

I confirm that my contributions will be compatible with the GPLv2.0 license guidelines.

* [ ] I have read and accepted both license and code of conduct.
* [x] I have previously accepted and still accept both license and code of conduct.
