### PR TITLE
update worksflow

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 skip_list:
-  - no-handler
   - role-name
+exclude_paths:
+  - .github

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,6 +1,6 @@
 name: Ansible Lint
 
-on: [push, pull_request]
+on: [push, pull_request] # noqua
 
 jobs:
   build:
@@ -8,13 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@main
-      with:
-        targets: ""
-        override-deps: |
-          ansible~=2.12
-          ansible-lint~=6.12
-        args: ""
+      - name: Lint Ansible Playbook
+        uses: ansible/ansible-lint-action@main

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This role configures the following.
 Version
 -------
 
+* `3.2.0` --- Added `root_keys_authorized_keys_file_owner` and `root_keys_authorized_keys_file_group`.
 * `3.1.1` --- Allow Fedora CoreOS 39 to run. No tests has been done
 * `3.1.0` --- Initial support for Fedora CoreOS, but with no tests. Also disabled coreos testing.
 * `3.0.1` --- bug fix, ansible-linting
@@ -72,6 +73,8 @@ Role Variables
 * `root_keys_users_limit` --- limit to only a list of root users, default `[]`
 * `root_keys_users_always` --- always add this list of root users, overrides `root_keys_users_limit`, default `['ansible']`
 * `root_keys_authorized_keys_file` --- path to the authorized_keys file of root, default `/root/.ssh/authorized_keys`
+* `root_keys_authorized_keys_file_owner` --- owner of the authorized_keys file, default `root`
+* `root_keys_authorized_keys_file_group` --- group of the authorized_keys file, default `root`
 * `root_remote_password_login` --- allow SSH root login with password, default `false`
 * `root_password` --- set root password hash, default not set and lock account
 * `root_ssh_config_path` --- path for `sshd_config`, default `/etc/ssh/sshd_config`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,5 +5,7 @@ root_keys_users_limit: []
 root_keys_users_always: []
 root_keys_users: []
 root_keys_authorized_keys_file: "/root/.ssh/authorized_keys"
+root_keys_authorized_keys_file_owner: root
+root_keys_authorized_keys_file_group: root
 root_remote_password_login: false
 root_ssh_config_path: /etc/ssh/sshd_config

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -11,7 +11,7 @@
     validate: 'sshd -t -f %s'
   register: linein_ssh_config
 
-- name: Reload sshd
+- name: Reload sshd  # noqa: no-handler
   ansible.builtin.service:
     name: '{{ sshd_service_name }}'
     state: reloaded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,5 +35,5 @@
     src: authorized_keys.j2
     dest: "{{ root_keys_authorized_keys_file }}"
     mode: '0600'
-    owner: 'root'
-    group: 'root'
+    owner: '{{ root_keys_authorized_keys_file_owner }}'
+    group: '{{ root_keys_authorized_keys_file_group }}'


### PR DESCRIPTION
Hi!

I'd like to contribute feature.

Allow for different owner of the root-keys authorized_key file. The role can be used in the cases where the authorized_keys are under a different user, but until now the owner and group of the file ended up as root. Example manage the ubuntu users' authorized_keys file.

Added two new options

* `root_keys_authorized_keys_file_owner`, default `root`
* `root_keys_authorized_keys_file_group`, default `root`

I confirm that my contributions will be compatible with the GPLv2.0 license guidelines.

* [ ] I have read and accepted both license and code of conduct.
* [x] I have previously accepted and still accept both license and code of conduct.
